### PR TITLE
Delete pentecost readme

### DIFF
--- a/gryphon/dashboards/README.md
+++ b/gryphon/dashboards/README.md
@@ -1,2 +1,0 @@
-# Pentecost
-Jaeger Commander


### PR DESCRIPTION
This file is unnecessary since this is not the root of any project anymore.