### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/gryphon/data_service/pollers/orderbook/websocket/bitstamp_orderbook_websocket.py
+++ b/gryphon/data_service/pollers/orderbook/websocket/bitstamp_orderbook_websocket.py
@@ -230,7 +230,7 @@ class BitstampOrderbookWebsocket(EmeraldWebSocketClientProtocol, WebsocketOrderb
 
         # Re-sort the asks.
         self.orderbook['asks'] = OrderedDict(
-            sorted(self.orderbook['asks'].iteritems(), key=lambda k_v: float(k_v[0])),
+            sorted(self.orderbook['asks'].items(), key=lambda k_v: float(k_v[0])),
         )
 
     def parse_orders(self, orders):

--- a/gryphon/data_service/pollers/orderbook/websocket/bitstamp_orderbook_websocket.py
+++ b/gryphon/data_service/pollers/orderbook/websocket/bitstamp_orderbook_websocket.py
@@ -218,7 +218,7 @@ class BitstampOrderbookWebsocket(EmeraldWebSocketClientProtocol, WebsocketOrderb
         # Re-sort the bids.
         self.orderbook['bids'] = OrderedDict(sorted(
             self.orderbook['bids'].iteritems(),
-            key=lambda (k, v): float(k),
+            key=lambda k_v1: float(k_v1[0]),
             reverse=True,
         ))
 
@@ -230,7 +230,7 @@ class BitstampOrderbookWebsocket(EmeraldWebSocketClientProtocol, WebsocketOrderb
 
         # Re-sort the asks.
         self.orderbook['asks'] = OrderedDict(
-            sorted(self.orderbook['asks'].iteritems(), key=lambda (k, v): float(k)),
+            sorted(self.orderbook['asks'].iteritems(), key=lambda k_v: float(k_v[0])),
         )
 
     def parse_orders(self, orders):

--- a/gryphon/data_service/pollers/orderbook/websocket/coinbase_orderbook_websocket.py
+++ b/gryphon/data_service/pollers/orderbook/websocket/coinbase_orderbook_websocket.py
@@ -309,13 +309,13 @@ class CoinbaseOrderbookWebsocket(EmeraldWebSocketClientProtocol, WebsocketOrderb
 
         sorted_bid_keys = sorted(
             fancy_orderbook['bids'].keys(),
-            key=lambda (k): float(k),
+            key=lambda k: float(k),
             reverse=True,
         )
 
         sorted_ask_keys = sorted(
             fancy_orderbook['asks'].keys(),
-            key=lambda (k): float(k),
+            key=lambda k: float(k),
         )
 
         bids = [[k, str(fancy_orderbook['bids'][k]), ''] for k in sorted_bid_keys]

--- a/gryphon/data_service/scripts/benchmark.py
+++ b/gryphon/data_service/scripts/benchmark.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Simple test script for benchmarking regular python logging vs twisted's logging.
 
 import logging
@@ -25,7 +26,7 @@ def tx_log():
 
 
 def stop():
-    print "Log Counter: %s" % log_counter
+    print("Log Counter: %s" % log_counter)
     reactor.stop()
 
 

--- a/gryphon/data_service/scripts/historical_trade_collector.py
+++ b/gryphon/data_service/scripts/historical_trade_collector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import csv
 from datetime import timedelta
 import gzip
@@ -161,7 +162,7 @@ def get_our_recorded_ticker_volume_for_period(exchange, start_date, end_date):
 def audit_ticker_volume_individual_days(exchange_list, start_date=test_start_date, end_date=test_end_date):
     d = start_date
     while d < test_end_date:
-        print '\n\nAuditing: %s' % d
+        print('\n\nAuditing: %s' % d)
         day_after = d + timedelta(days=1)
         audit_all_ticker_volume(exchange_list, d, day_after)
         d = day_after
@@ -191,12 +192,12 @@ def audit_ticker_volume(exchange, start_date, end_date):
         end_date,
     )
 
-    print '%s  Our Volume:%s  Ticker Volume:%s, Accuracy: %s' % (
+    print('%s  Our Volume:%s  Ticker Volume:%s, Accuracy: %s' % (
         exchange,
         our_volume,
         ticker_volume,
         our_volume / ticker_volume,
-    )
+    ))
 
 
 def audit_bw_volume(exchange, start_date, end_date):
@@ -204,7 +205,7 @@ def audit_bw_volume(exchange, start_date, end_date):
     bw_volume = bw_exchange.volume_in_period(start_date, end_date)
 
     our_volume = get_our_recorded_exchange_trade_volume_for_period(exchange, start_date, end_date)
-    print '%s  Our Volume:%s  BW Volume:%s, Accuracy: %s' % (exchange, our_volume, bw_volume, our_volume / bw_volume)
+    print('%s  Our Volume:%s  BW Volume:%s, Accuracy: %s' % (exchange, our_volume, bw_volume, our_volume / bw_volume))
 
 
 def compare_all_exchanges():
@@ -222,15 +223,15 @@ def compare_ours_to_history(our_exchange_id, exchange, price_currency, volume_cu
     start = parse('2015-11-27 0:0:0').datetime.replace(tzinfo=None)
     end = parse('2015-11-27 11:59:59').datetime.replace(tzinfo=None)
 
-    print our_exchange_id.upper()
+    print(our_exchange_id.upper())
     hist_in_range = [t for t in hist_trades if t[0] >= start and t[0] <= end]
     ours_in_range = [t for t in our_trades if t[0] >= start and t[0] <= end]
 
     for t in hist_in_range:
         if t not in ours_in_range:
-            print 'Hist Trade not in ours: %s' % t
+            print('Hist Trade not in ours: %s' % t)
 
     for t in ours_in_range:
         if t not in hist_in_range:
-            print'Our trade not in history: %s' % t
-    print'\n\n\n\n\n'
+            print('Our trade not in history: %s' % t)
+    print('\n\n\n\n\n')

--- a/gryphon/execution/controllers/create_dashboard_user.py
+++ b/gryphon/execution/controllers/create_dashboard_user.py
@@ -5,6 +5,7 @@ database.
 
 Usage: gryphon-exec create-dashboard-user [--execute]
 """
+from __future__ import print_function
 
 import getpass
 import termcolor as tc
@@ -43,14 +44,14 @@ Success! You should be able to log in with the new credentials now.'\
 
 
 def main(execute):
-    print tc.colored(WARNING_MESSAGE, 'red')
+    print(tc.colored(WARNING_MESSAGE, 'red'))
     informed_consent = raw_input(WARNING_PROMPT)
 
     if informed_consent != 'y':
-        print EXIT_MESSAGE
+        print(EXIT_MESSAGE)
         return
     else:
-        print CONTINUE_MESSAGE
+        print(CONTINUE_MESSAGE)
 
     dashboard_db = session.get_a_dashboard_db_mysql_session()
 
@@ -65,7 +66,7 @@ def main(execute):
         dashboard_db.add(user)
         dashboard_db.commit()
 
-        print tc.colored(SUCCESS_MESSAGE, 'green')
+        print(tc.colored(SUCCESS_MESSAGE, 'green'))
     else:
-        print SUCCESS_NO_EXECUTE_MESSAGE
+        print(SUCCESS_NO_EXECUTE_MESSAGE)
      

--- a/gryphon/execution/controllers/fee_buyback.py
+++ b/gryphon/execution/controllers/fee_buyback.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import prompter
 import termcolor as tc
 
@@ -14,7 +15,7 @@ def buyback():
     prompt_msg = tc.colored('Did you stop the Coinbase Bot before running this?', 'red')
     bot_stopped = prompter.yesno(prompt_msg)
     if not bot_stopped:
-        print tc.colored('Go stop the bot first.', 'red')
+        print(tc.colored('Go stop the bot first.', 'red'))
         return
 
     db = session.get_a_trading_db_mysql_session()
@@ -33,7 +34,7 @@ def buyback():
         transactions_buyback_amount = sum([t.fee for t in transactions_with_outstanding_fees])
         btc_buyback_amount = trades_buyback_amount + transactions_buyback_amount
 
-        print 'Go buy %s on Coinbase (not the exchange)' % btc_buyback_amount
+        print('Go buy %s on Coinbase (not the exchange)' % btc_buyback_amount)
 
         prompt_msg = 'How much USD did it cost (total including Coinbase Fee): USD'
         raw_usd_cost = prompter.prompt(prompt_msg)

--- a/gryphon/execution/controllers/initialize_ledger.py
+++ b/gryphon/execution/controllers/initialize_ledger.py
@@ -15,6 +15,7 @@ Usage:
         [comma-separated list of exchange pairs, e.g. 'bitstamp_btc_usd,gemini_btc_usd']
         [--execute]
 """
+from __future__ import print_function
 
 import pyximport; pyximport.install()
 
@@ -53,7 +54,7 @@ def initialize_exchange_ledger(db, wrapper_obj):
         pass
     finally:
         if db_obj is not None:
-            print ALREADY_INITIALIZED_ERR_MESSAGE % wrapper_obj.name
+            print(ALREADY_INITIALIZED_ERR_MESSAGE % wrapper_obj.name)
             return
 
     # Create the entry in the Exchange table.
@@ -66,12 +67,12 @@ def initialize_exchange_ledger(db, wrapper_obj):
     try:
         balance = wrapper_obj.get_balance()
     except KeyError as e:
-        print NO_API_CREDENTIALS_ERR_MESSAGE % wrapper_obj.name
-        print e
+        print(NO_API_CREDENTIALS_ERR_MESSAGE % wrapper_obj.name)
+        print(e)
         return
     except Exception as e:
-        print UNKNOWN_ERR_MESSAGE % wrapper_obj.name
-        print e
+        print(UNKNOWN_ERR_MESSAGE % wrapper_obj.name)
+        print(e)
         return
 
     price_currency = wrapper_obj.currency

--- a/gryphon/execution/lib/config.py
+++ b/gryphon/execution/lib/config.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ConfigParser
 
 from gryphon.lib.logger import get_logger
@@ -6,7 +7,7 @@ logger = get_logger(__name__)
 
 
 def get_config_var(filepath, section, key):
-    print filepath
+    print(filepath)
 
     config = ConfigParser.RawConfigParser()
     config.read(filepath)

--- a/gryphon/execution/live_runner.py
+++ b/gryphon/execution/live_runner.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pyximport; pyximport.install()
 from cdecimal import Decimal
 import inspect
@@ -253,7 +254,7 @@ def live_run(configuration):
         while True:
             try:
                 tick_start = Delorean().epoch
-                print '\n\n%s' % strategy.name
+                print('\n\n%s' % strategy.name)
 
                 if warm_shutdown_flag:
                     return  # This takes us into the finally block.

--- a/gryphon/execution/scripts/itbit_auth_test.py
+++ b/gryphon/execution/scripts/itbit_auth_test.py
@@ -2,6 +2,7 @@
 This is a minimal script that demonstrates authentication on itbit. This is useful for
 debugging if you ever run into issues with authenticating on itbit.
 """
+from __future__ import print_function
 
 import base64
 import hashlib
@@ -59,5 +60,5 @@ def main(script_arguments, execute):
 
     full_url = 'https://api.itbit.com/v1' + url
 
-    print requests.get(full_url, data=request_args).text
+    print(requests.get(full_url, data=request_args).text)
 

--- a/gryphon/lib/analysis/legacy/average_true_range.py
+++ b/gryphon/lib/analysis/legacy/average_true_range.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 from exponential_moving_average import ExpMovingAverage
 
@@ -12,9 +13,9 @@ def TR(d,c,h,l,o,yc):
     y = abs(h-yc)
     z = abs(l-yc)
 
-    print x
-    print y
-    print z
+    print(x)
+    print(y)
+    print(z)
 
     if y <= x >= z:
         TR = x
@@ -23,7 +24,7 @@ def TR(d,c,h,l,o,yc):
     elif x <= z >= y:
         TR = z
 
-    print d, TR
+    print(d, TR)
     return d, TR
 
 x = 1
@@ -39,7 +40,7 @@ while x < len(date):
 
 
 
-print len(TrueRanges)
+print(len(TrueRanges))
 ATR = ExpMovingAverage(TrueRanges,14)
 
-print ATR
+print(ATR)

--- a/gryphon/lib/analysis/legacy/chaikin_volatility.py
+++ b/gryphon/lib/analysis/legacy/chaikin_volatility.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import time
 
@@ -32,10 +33,10 @@ def chaikinVolCalc(emaUsed,periodsAgo):
         highMlow.append(hml)
         x += 1
 
-    print len(date)
-    print len(highMlow)
+    print(len(date))
+    print(len(highMlow))
     highMlowEMA = ExpMovingAverage(highMlow,emaUsed)
-    print len(highMlowEMA)
+    print(len(highMlowEMA))
     y = emaUsed + periodsAgo
 
     while y < len(date):
@@ -43,7 +44,7 @@ def chaikinVolCalc(emaUsed,periodsAgo):
         chaikin_volatility.append(cvc)
         y+=1
 
-    print len(date[emaUsed+periodsAgo:])
+    print(len(date[emaUsed+periodsAgo:]))
     
     return date[emaUsed+periodsAgo:], chaikin_volatility
         

--- a/gryphon/lib/analysis/legacy/chart.py
+++ b/gryphon/lib/analysis/legacy/chart.py
@@ -207,7 +207,7 @@ def graphData(stock,MA1,MA2):
         plt.show()
         fig.savefig('example.png',facecolor=fig.get_facecolor())
            
-    except Exception,e:
+    except Exception as e:
         print 'main loop',str(e)
 
 while True:

--- a/gryphon/lib/analysis/legacy/ease_of_movement.py
+++ b/gryphon/lib/analysis/legacy/ease_of_movement.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import time
 
@@ -25,13 +26,13 @@ def EMV(d,c,h,l,o,v,tf):
         boxr = ( (v[x]/1000000.00)/ (h[x]-l[x]) )
         OnepEMVs = movement / boxr
         OnepEMV.append(OnepEMVs)
-        print OnepEMVs
+        print(OnepEMVs)
         x += 1
 
     tfEMV = movingaverage(OnepEMV,tf)
 
-    print len(tfEMV)
-    print len(d[tf:])
+    print(len(tfEMV))
+    print(len(d[tf:]))
 
     return d[tf:],tfEMV
 

--- a/gryphon/lib/analysis/legacy/elder_force_index.py
+++ b/gryphon/lib/analysis/legacy/elder_force_index.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import time
 
@@ -23,7 +24,7 @@ def EFI(d,c,v,tf):
     x = 1
     while x < len(d):
         forceIndex = (c[x] - c[x-1]) * v[x]
-        print forceIndex
+        print(forceIndex)
         efi.append(forceIndex)
         x+=1
     efitf = ExpMovingAverage(efi,tf)

--- a/gryphon/lib/analysis/legacy/gapo.py
+++ b/gryphon/lib/analysis/legacy/gapo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import time
 import math
@@ -23,7 +24,7 @@ def GAPO(d,h,l,tf):
         gapos = ( (math.log(HighestHigh - LowestLow)) /
                   math.log(tf))
 
-        print gapos
+        print(gapos)
         gapo.append(gapos)
         x+=1
     return d[tf:],gapo

--- a/gryphon/lib/analysis/legacy/swing_index.py
+++ b/gryphon/lib/analysis/legacy/swing_index.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #November 11th 2013:
 open1 = 1286.50
 high1 = 1287.70
@@ -18,25 +19,25 @@ def SwingIndex(O1,O2,H1,H2,L1,L2,C1,C2,LM):
         x = H2-C1
         y = L2-C1
         z = H2-L2
-        print x
-        print y
-        print z
+        print(x)
+        print(y)
+        print(z)
 
         if z < x > y:
-            print 'x wins!'
+            print('x wins!')
             R = (H2-C1)-(.5*(L2-C1))+(.25*(C1-O1))
-            print R
+            print(R)
             return R
         elif x < y > z:
-            print 'y wins!'
+            print('y wins!')
             R = (L2-C1)-(.5*(H2-C1))+(.25*(C1-O1))
-            print R
+            print(R)
             return R
 
         elif x < z > y:
-            print 'z wins!'
+            print('z wins!')
             R = (H2-L2)+(.25*(C1-O1))
-            print R
+            print(R)
             return R
 
 
@@ -46,11 +47,11 @@ def SwingIndex(O1,O2,H1,H2,L1,L2,C1,C2,LM):
 
         if x > y:
             K=x
-            print K
+            print(K)
             return K
         elif x < y:
             K=y
-            print K
+            print(K)
             return K
 
     L = LM
@@ -58,8 +59,8 @@ def SwingIndex(O1,O2,H1,H2,L1,L2,C1,C2,LM):
     K = calc_K(H2,L2,C1)
 
     SwIn = 50*((C2-C1+(.5*(C2-O2))+(.25*(C1-O1)))/R)*(K/L)
-    print '###'
-    print SwIn
+    print('###')
+    print(SwIn)
     
 
 

--- a/gryphon/lib/configuration.py
+++ b/gryphon/lib/configuration.py
@@ -86,7 +86,7 @@ def parse_configurable_value(value):
     """
     if value is None:
         return None
-    if type(value) is bool:
+    if isinstance(value, bool):
         return value
     elif value == 'yes':
         return True

--- a/gryphon/lib/debugging/bitstamp_cert_error.py
+++ b/gryphon/lib/debugging/bitstamp_cert_error.py
@@ -44,6 +44,7 @@ pip install requests[security]
 Make sure you have yoru bitstamp credentials in a .env file in the directory you are
 running from.
 """
+from __future__ import print_function
 
 import requests
 import hmac
@@ -67,8 +68,8 @@ API_BALANCE_URL = 'https://www.bitstamp.net/api/v2/balance/'
 
 
 def requests_dot_post():
-    print '---'
-    print "Trying requests.post"
+    print('---')
+    print("Trying requests.post")
 
     nonce = unicode(int(round(time.time() * 1000)))
     message = nonce + CLIENT_ID + API_KEY
@@ -82,27 +83,27 @@ def requests_dot_post():
 
     result = requests.post(API_BALANCE_URL, data=payload).text
 
-    print 'Response from bitstamp: %s' % result[:50]
+    print('Response from bitstamp: %s' % result[:50])
 
     try:
         assert('btc_available' in result)
-        print 'requests.post succeeded!'
+        print('requests.post succeeded!')
     except Exception as e:
-        print 'requests.post failed: %s' % str(e)
+        print('requests.post failed: %s' % str(e))
 
 
 def session_post(session=None, clear_cookies=None):
-    print '---'
+    print('---')
 
     if session is None:
-        print "Trying with a new session"
+        print("Trying with a new session")
 
         session = requests.Session()
     else:
-        print "Trying with an extant session"
+        print("Trying with an extant session")
 
         if clear_cookies is True:
-            print "Clearing the session's cookies"
+            print("Clearing the session's cookies")
             session.cookies.clear()
 
     nonce = unicode(int(round(time.time() * 1000)))
@@ -117,13 +118,13 @@ def session_post(session=None, clear_cookies=None):
 
     result = session.post(API_BALANCE_URL, payload).text
 
-    print 'Response from bitstamp: %s' % result[:50]
+    print('Response from bitstamp: %s' % result[:50])
 
     try:
         assert('btc_available' in result)
-        print 'Session succeeded!'
+        print('Session succeeded!')
     except Exception as e:
-        print 'Session failed: %s' % str(e)
+        print('Session failed: %s' % str(e))
 
     return session
 

--- a/gryphon/lib/models/atlaszero/metric_types.py
+++ b/gryphon/lib/models/atlaszero/metric_types.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from gryphon.lib.exchange.exchange_factory import ALL_EXCHANGE_KEYS as all_exchanges
 from gryphon.lib.util.list import distinct
 
@@ -5534,7 +5535,7 @@ def generate_initial_series_name_list():
     for st in series_types_orderbook_data:
         for exchange in all_exchanges:
             for depth in depths_on_orderbook_data:
-                print "    '%s-%s-%s': %s," % (st, exchange, depth, count)
+                print("    '%s-%s-%s': %s," % (st, exchange, depth, count))
                 count += 1
 
     series_types_on_trade_data = ['volume', 'vwap']
@@ -5543,5 +5544,5 @@ def generate_initial_series_name_list():
     for st in series_types_on_trade_data:
         for exchange in all_exchanges:
             for info in info_on_trade_data:
-                print "    '%s-%s-%s': %s," % (st, exchange, info, count)
+                print("    '%s-%s-%s': %s," % (st, exchange, info, count))
                 count += 1

--- a/gryphon/lib/scrapers/bmo.py
+++ b/gryphon/lib/scrapers/bmo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import logging
 import os
 
@@ -285,9 +286,9 @@ class AnyEc:
 
 def main():
     scraper = BMOScraper()
-    print scraper.load()
-    print scraper.load_transactions(os.environ['BMO_USD_ACCOUNT_NUMBER'])
-    print scraper.load_transactions(os.environ['BMO_CAD_ACCOUNT_NUMBER'])
+    print(scraper.load())
+    print(scraper.load_transactions(os.environ['BMO_USD_ACCOUNT_NUMBER']))
+    print(scraper.load_transactions(os.environ['BMO_CAD_ACCOUNT_NUMBER']))
     scraper.quit()
 
 if __name__ == '__main__':

--- a/gryphon/lib/scrapers/boa.py
+++ b/gryphon/lib/scrapers/boa.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import gryphon.lib; gryphon.lib.prepare()
 
 import os
@@ -82,8 +83,8 @@ class BoAScraper(Scraper):
 
 def main():
     scraper = BoAScraper()
-    print scraper.load()
-    print scraper.load_transactions(os.environ['BOA_MAIN_ACCOUNT_NUMBER'])
+    print(scraper.load())
+    print(scraper.load_transactions(os.environ['BOA_MAIN_ACCOUNT_NUMBER']))
     scraper.quit()
 
 if __name__ == '__main__':

--- a/gryphon/lib/scripts/bitstamp_auth_test.py
+++ b/gryphon/lib/scripts/bitstamp_auth_test.py
@@ -2,6 +2,7 @@
 This script demonstrates the bitstamp authenticated requests bug that showed up in the
 week of 26 March.
 """
+from __future__ import print_function
 
 import requests
 import hmac
@@ -38,13 +39,13 @@ def construct_payload():
 
 
 def test_response(response, test_name):
-    print 'Response: %s' % str(response)[:50]
+    print('Response: %s' % str(response)[:50])
 
     try:
         assert('btc_available' in response)
-        print '%s succeeded!' % test_name
+        print('%s succeeded!' % test_name)
     except Exception as e:
-        print '%s: %s' % (test_name, str(e))
+        print('%s: %s' % (test_name, str(e)))
 
 
 def requests_dot_post():
@@ -52,7 +53,7 @@ def requests_dot_post():
     This just makes a single request.post call to see if it works.
     """
 
-    print "Trying requests.post"
+    print("Trying requests.post")
 
     payload = construct_payload()
 
@@ -68,7 +69,7 @@ def session_post(session=None, clear_cookies=None, adaptor=None, cookie_jar=None
     types.
     """
     if session is None:
-        print "Trying with a new session"
+        print("Trying with a new session")
         session = requests.Session()
 
         if adaptor is not None:
@@ -77,10 +78,10 @@ def session_post(session=None, clear_cookies=None, adaptor=None, cookie_jar=None
         if cookie_jar is not None:
             session.cookies = cookie_jar
     else:
-        print "Trying with an extant session"
+        print("Trying with an extant session")
 
         if clear_cookies is True:
-            print "Clearing the session's cookies"
+            print("Clearing the session's cookies")
             session.cookies.clear()
 
     payload = construct_payload()
@@ -107,15 +108,15 @@ def try_different_adaptors():
     tls1 = SSLAdapter(ssl.PROTOCOL_TLSv1)
     tls11 = SSLAdapter(ssl.PROTOCOL_TLSv1_1)
 
-    print 'TLSv1'
+    print('TLSv1')
     session = session_post(adaptor=tls1)
     session_post(session=session)
 
-    print 'TLSv1'
+    print('TLSv1')
     session = session_post(adaptor=tls11)
     session_post(session=session)
 
-    print 'SSLv3'
+    print('SSLv3')
     session = session_post(adaptor=ssl3)
     session_post(session=session)
 

--- a/gryphon/lib/scripts/test_fast_revenue_fees_profit.py
+++ b/gryphon/lib/scripts/test_fast_revenue_fees_profit.py
@@ -2,6 +2,7 @@
 Test script for the new fast revenue function. Runs both revenue functions on a
 random period and checks their results are the same.
 """
+from __future__ import print_function
 
 import pyximport; pyximport.install()
 
@@ -39,7 +40,7 @@ def test_fast_revenue():
     for i in range(1, 30):
         start, end = get_random_period()
 
-        print '%s, %s' % (start, end)
+        print('%s, %s' % (start, end))
 
         slow_revenue = gryphon_profit.revenue_in_period(db, start, end)
         fast_revenue = gryphon_profit.fast_revenue_in_period(db, start, end)
@@ -51,9 +52,9 @@ def test_fast_revenue():
                       == fast_revenue.round_to_decimal_places(4))
 
         if not result:
-            print 'BAD: %s, != %s' % (slow_revenue, fast_revenue)
+            print('BAD: %s, != %s' % (slow_revenue, fast_revenue))
         else:
-            print 'GOOD: %s, == %s' % (slow_revenue, fast_revenue)
+            print('GOOD: %s, == %s' % (slow_revenue, fast_revenue))
 
     db.remove()
 
@@ -64,7 +65,7 @@ def test_fast_profit():
     for i in range(1, 30):
         start, end = get_random_period()
 
-        print '%s, %s' % (start, end)
+        print('%s, %s' % (start, end))
 
         slow_profit = gryphon_profit.profit_in_period(db, start, end)
         fast_profit = gryphon_profit.fast_profit_in_period(db, start, end)
@@ -73,9 +74,9 @@ def test_fast_profit():
                       == fast_profit.round_to_decimal_places(4))
 
         if not result:
-            print 'BAD: %s, != %s' % (slow_profit, fast_profit)
+            print('BAD: %s, != %s' % (slow_profit, fast_profit))
         else:
-            print 'GOOD: %s, == %s' % (slow_profit, fast_profit)
+            print('GOOD: %s, == %s' % (slow_profit, fast_profit))
 
     db.remove()
 
@@ -86,7 +87,7 @@ def test_fast_revenue_fees_profit():
     for i in range(1, 30):
         start, end = get_random_period()
 
-        print '%s, %s' % (start, end)
+        print('%s, %s' % (start, end))
 
         slow_revenue, slow_fees, slow_profit = gryphon_profit.revenue_fees_profit_in_period(db, start, end)
         fast_revenue, fast_fees, fast_profit = gryphon_profit.fast_revenue_fees_profit_in_period(db, start, end)
@@ -99,9 +100,9 @@ def test_fast_revenue_fees_profit():
                       == fast_fees.round_to_decimal_places(4))
 
         if not result:
-            print 'BAD'
+            print('BAD')
         else:
-            print 'GOOD'
+            print('GOOD')
 
     db.remove()
 


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.