### PR TITLE
Fix install instructions for macOS

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -95,6 +95,7 @@ The installation steps for OSX are the same as for ubuntu, but instead of aptitu
       
       brew install python@2
       brew install mysql
+      brew install libmemcached
       brew install memcached
 
 The rest of the steps are identical to those for Ubuntu 16.04.


### PR DESCRIPTION
Without this extra library, errors occur while installing dependencies:

```
Searching for pylibmc<2,>=1.5.2
Reading https://pypi.org/simple/pylibmc/
Downloading https://files.pythonhosted.org/packages/f4/09/58b9621fc4e0433037b70f053e51a053406e75ec5f68522dcb887792bc1f/pylibmc-1.6.0.tar.gz#sha256=5ef97be4ca5527d5b87dbe77cfdd94b427028caf4136feff7da23c40e1ded6d8
Best match: pylibmc 1.6.0
Processing pylibmc-1.6.0.tar.gz
Writing /var/folders/4m/f_g2p3cd4vz6l2w2w7pg9pf00000gp/T/easy_install-m7b6c1di/pylibmc-1.6.0/setup.cfg
Running pylibmc-1.6.0/setup.py -q bdist_egg --dist-dir /var/folders/4m/f_g2p3cd4vz6l2w2w7pg9pf00000gp/T/easy_install-m7b6c1di/pylibmc-1.6.0/egg-dist-tmp-q5nmdhaq
warning: no files found matching 'runtests.py'
warning: no files found matching '*.py' under directory 'pylibmc'
In file included from src/_pylibmcmodule.c:34:
src/_pylibmcmodule.h:42:10: fatal error: 'libmemcached/memcached.h' file not found
#include <libmemcached/memcached.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
error: Setup script exited with error: command 'gcc' failed with exit status 1
```