### PR TITLE
SQLite as dashboard DB.

### DIFF
--- a/gryphon/lib/session.py
+++ b/gryphon/lib/session.py
@@ -41,8 +41,9 @@ def get_a_mysql_session(creds):
     engine = sqlalchemy.create_engine(
         creds,
         echo=False,
-        pool_size=3,
-        pool_recycle=3600,
+
+        #pool_size=3,
+        #pool_recycle=3600,
     )
 
     session = scoped_session(sessionmaker(bind=engine))


### PR DESCRIPTION
Change your dashboard `.env` to have something along the lines of : 
```
DASHBOARD_DB_CRED="sqlite:///dashboard.db"
```
Ref : https://docs.sqlalchemy.org/en/13/core/engines.html#sqlite

Then everything should work as usual, but with sqlite. The DB is just a file created on your disk.

@garethdmm This makes testing with a database created on the fly, solely for testing, and no extra setup, quite simple to do.


I m not yet sure what should be the logic to adopt here, when initializing the sqlalchemy engine, so that it works as expected with both sqlite and mysql... but having these parameters for sqlite as well gives : 
```
TypeError: Invalid argument(s) 'pool_size' sent to create_engine(), using configuration SQLiteDialect_pysqlite/NullPool/Engine.  Please check that the keyword arguments are appropriate for this combination of components.
```

Also I couldn't find tests for it, but we should probably have some...

