### PR TITLE
Dashboard Packaging Error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ global-include *.ini
 include gryphon/execution/migrations/versions/*.py
 include gryphon/data_service/migrations/versions/*.py
 include gryphon/dashboards/migrations/versions/*.py
+recursive-include gryphon/dashboards/templates/ *.html
+recursive-include gryphon/dashboards/static/ *.js *.css *.png *.ico

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open('README.md', 'r') as f:
 setuptools.setup(
     name='gryphon',
     packages=setuptools.find_packages(),
-    version='0.11',
+    version='0.11.2',
     author='MacLeod & Robinson, Inc.',
     author_email='hello@tinkercorp.com',
     description='A framework for running algorithmic trading strategies on cryptocurrency markets.',


### PR DESCRIPTION
Slack user maximaus was having an issue running the dashboard server from a pypi installation. Digging into it, I found our MANIFEST.in was not properly including html/css/js files in the dashboard directory, so pypi installations were unable to run the dashboard server.

This change updates MANIFEST.in to include those files.

Testing:
- Bug reproduction: I ran `pip install gryphon` inside a new virtualenv with my dashboard configuration and attempted to load the welcome page. I got a 500 error that said it couldn't find the .html file
- Fix: I generated a new wheel file from this branch and installed it with pip. I was able to load the welcome page. Explicit instructions follow:
```
# From your local gryphon source directory in a clean virtualenv
git checkout packaging
python setup.py clean
python setup.py bdist_wheel
pip uninstall
pip install dist/gryphon-0.11.2-py2-none-any.whl
gryphon-dashboards
# navigate to localhost:8080 and you should see a login screen and certainly not get a 500 error
```
