### PR TITLE
passing eaten_orders from consolidating_ledgers to strategy tick.

### DIFF
--- a/gryphon/execution/harness/exchange_coordinator.pyx
+++ b/gryphon/execution/harness/exchange_coordinator.pyx
@@ -76,7 +76,7 @@ class ExchangeCoordinator(object):
         eaten_order_ids, current_orders = self._get_current_orders(open_orders)
         self._run_accounting(eaten_order_ids, current_orders)
 
-        return current_orders
+        return current_orders, eaten_order_ids
 
     @tick_profile
     def _get_current_orders(self, exchange_open_orders):


### PR DESCRIPTION
I found  strange that base strategy had this interface : https://github.com/garethdmm/gryphon/blob/master/gryphon/execution/strategies/base.pyx#L71 where as example strategies had a different one : https://github.com/garethdmm/gryphon/blob/master/gryphon/execution/strategies/builtin/simple_market_making.pyx#L40

This aims at fixing that.
There is probably a lot of places where this change needs to be propagated...