### PR TITLE
Run the flake8 tests on legacy Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install .
 
 before_script:
-	  - pip install flake8
-	  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - pip install flake8
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 script: gryphon-runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 
 before_script:
   - pip install flake8
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  # TODO: Fix the flake8 tests and the remove the --exit-zero
+  - flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
 
 script: gryphon-runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ python:
 install:
   - pip install .
 
+before_script:
+	  - pip install flake8
+	  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
 script: gryphon-runtests


### PR DESCRIPTION
See #20 for the changes required to make the tests pass.