### PR TITLE
fixed itbit place order bug.. issue 11

### DIFF
--- a/gryphon/lib/exchange/itbit_btc_usd.py
+++ b/gryphon/lib/exchange/itbit_btc_usd.py
@@ -305,9 +305,9 @@ class ItbitBTCUSDExchange(ExchangeAPIWrapper):
 
         # Truncate the volume instead of rounding it because it's better# to trade too
         # little than too much.
-        volume = volume.round_to_decimal_places(2, rounding=cdecimal.ROUND_DOWN)
+        volume = volume.round_to_decimal_places(8, rounding=cdecimal.ROUND_DOWN)
 
-        volume_str = '%.2f' % volume.amount
+        volume_str = '%.8f' % volume.amount
         price_str = '%.2f' % price.amount
 
         payload = {


### PR DESCRIPTION
This makes it so you can trade itbit at less than 0.01 BTC at a time when placing an order.  Present version sends orders with a volume of 0.00 BTC if it is less than 0.01 BTC.