### PR TITLE
updated fees.. added links to fee schedules adjacent to fee variable …

### DIFF
--- a/gryphon/lib/exchange/bitfinex_btc_usd.py
+++ b/gryphon/lib/exchange/bitfinex_btc_usd.py
@@ -35,6 +35,9 @@ class BitfinexBTCUSDExchange(ExchangeAPIWrapper):
         # Configurables with defaults.
         self.market_order_fee = Decimal('0.002')
         self.limit_order_fee = Decimal('0.001')
+        # NOTE: Fees can and do change.  Present defaults aren't guaranteed accurate
+        # For this exchange you can find them here: https://www.bitfinex.com/fees
+
         self.fee = Decimal('0.00')
         self.fiat_balance_tolerance = Money('0.01', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')

--- a/gryphon/lib/exchange/bitstamp_btc_usd.py
+++ b/gryphon/lib/exchange/bitstamp_btc_usd.py
@@ -51,7 +51,10 @@ class BitstampBTCUSDExchange(ExchangeAPIWrapper):
         # Configurables defaults.
         self.market_order_fee = self.fee
         self.limit_order_fee = self.fee
-        self.fee = Decimal('0.0005')  # TODO: update these.
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here: https://www.bitstamp.net/fee-schedule/
+
+        self.fee = Decimal('0.005')  # updated 31 JAN 2020
         self.fiat_balance_tolerance = Money('0.0001', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')
         self.max_tick_speed = 1

--- a/gryphon/lib/exchange/coinbase_btc_usd.py
+++ b/gryphon/lib/exchange/coinbase_btc_usd.py
@@ -39,8 +39,12 @@ class CoinbaseBTCUSDExchange(ExchangeAPIWrapper):
         self.price_decimal_precision = 2
 
         # Configurables with defaults.
-        self.market_order_fee = Decimal('0.0022') # Updated by Gareth on 2016-9-20
-        self.limit_order_fee = Decimal('0.001')
+        self.market_order_fee = Decimal('0.005') # Updated fees 31 JAN 2020
+        self.limit_order_fee = Decimal('0.005')
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here:
+        # https://help.coinbase.com/en/pro/trading-and-funding/trading-rules-and-fees/fees.html
+
         self.fee = self.market_order_fee
         self.fiat_balance_tolerance = Money('0.0001', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')

--- a/gryphon/lib/exchange/gemini_btc_usd.py
+++ b/gryphon/lib/exchange/gemini_btc_usd.py
@@ -40,8 +40,12 @@ class GeminiBTCUSDExchange(ExchangeAPIWrapper):
         self.gemini_pair_symbol = 'btcusd'
 
         # Configurables with defaults.
-        self.market_order_fee = Decimal('0.0025')  # Updated by Gareth on 2016-9-20.
-        self.limit_order_fee = Decimal('0.0000')
+        self.market_order_fee = Decimal('0.0035')  # Updated fees 31 JAN 2020
+        self.limit_order_fee = Decimal('0.0010')
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here:
+        # https://gemini.com/fees/api-fee-schedule#block-trading
+
         self.fee = self.market_order_fee
         self.fiat_balance_tolerance = Money('0.0001', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')

--- a/gryphon/lib/exchange/itbit_btc_usd.py
+++ b/gryphon/lib/exchange/itbit_btc_usd.py
@@ -38,8 +38,11 @@ class ItbitBTCUSDExchange(ExchangeAPIWrapper):
         self.nonce = 1
 
         # Configurables with defaults.
-        self.market_order_fee = Decimal('0.002')
-        self.limit_order_fee = Decimal('0')
+        self.market_order_fee = Decimal('0.0035')  # updated fees 31 JAN 2020
+        self.limit_order_fee = Decimal('-0.0003')
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here: https://www.itbit.com/fees
+
         self.fee = self.market_order_fee
         self.fiat_balance_tolerance = Money('0.0001', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')
@@ -64,7 +67,7 @@ class ItbitBTCUSDExchange(ExchangeAPIWrapper):
         assert '?' not in url
 
         if 'params' in kwargs:
-            if kwargs['params']: # Check that it's not empty.
+            if kwargs['params']:  # Check that it's not empty.
                 url += '?' + urllib.urlencode(kwargs['params'])
 
             del kwargs['params']

--- a/gryphon/lib/exchange/kraken_btc_eur.py
+++ b/gryphon/lib/exchange/kraken_btc_eur.py
@@ -42,8 +42,12 @@ class KrakenBTCEURExchange(ExchangeAPIWrapper):
         self.orderbook_depth = 100000
 
         # Configurables with defaults.
-        self.market_order_fee = Decimal('0.0014')
-        self.limit_order_fee = Decimal('0.0004')
+        self.market_order_fee = Decimal('0.0026')  # updated fees 31 JAN 2020
+        self.limit_order_fee = Decimal('0.00016')
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here:
+        # https://www.kraken.com/en-us/features/fee-schedule
+
         self.fee = self.market_order_fee
         self.fiat_balance_tolerance = Money('0.0001', 'EUR')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')

--- a/gryphon/lib/exchange/kraken_btc_usd.py
+++ b/gryphon/lib/exchange/kraken_btc_usd.py
@@ -16,9 +16,8 @@ class KrakenBTCUSDExchange(KrakenBTCEURExchange):
         self.currency = 'USD'
         self.price_decimal_precision = 1 # As of Feb 2018
 
-        # Updated by Gareth on 2016-9-20
-        self.market_order_fee = Decimal('0.0024')
-        self.limit_order_fee = Decimal('0.0014')
+        self.market_order_fee = Decimal('0.0026') # updated 31 JAN 2020
+        self.limit_order_fee = Decimal('0.0016')
         self.fee = self.market_order_fee
         self.fiat_balance_tolerance = Money('0.0001', 'USD')
         self.volume_balance_tolerance = Money('0.00000001', 'BTC')

--- a/gryphon/lib/exchange/okcoin_btc_usd.py
+++ b/gryphon/lib/exchange/okcoin_btc_usd.py
@@ -77,8 +77,12 @@ class OKCoinBTCUSDExchange(ExchangeAPIWrapper):
         }
 
         # Configurables with defaults.
-        self.market_order_fee = Decimal('0.001')
-        self.limit_order_fee = Decimal('0.002')
+        self.market_order_fee = Decimal('0.002')  # Updated 31 JAN 2020
+        self.limit_order_fee = Decimal('0.001')
+        # NOTE: Fees can and do change.  Present fees aren't guaranteed accurate
+        # For this exchange you can find them here:
+        # https://support.okcoin.com/hc/en-us/articles/360015261532-OKCoin-Fee-Rates
+        
         self.fee = self.market_order_fee
         self.withdrawal_fee = Money('0.001', 'BTC')
         self.use_cached_orderbook = False


### PR DESCRIPTION
This PR updated all the fees in the exchange wrappers.  Also added links to the fee tables for each exchange right next to the market and limit order fee variables.

Inspired by Issue # 42, specifically "keep reference links around in the source, and rely on a developer modifying the default values when the exchange happens to change its fees policy."
